### PR TITLE
Update doc, highlight and indent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ following features:
 	- [x] Symbols nesting
 	- [x] Configurable kinds' name and icon
 	- [x] Auto-refresh symbol list
+        - [x] Follow cursor
 - [ ] Commands
 	- [x] Jump to symbols, open symbol in split,... (`open_split` and friends)
 	- [x] Rename symbols (`rename`)
@@ -578,6 +579,8 @@ following features:
    - [x] LSP Support
    - [x] LSP server selection (blacklist, use first, use all, etc.)
 - [ ] CoC Support
+
+See #879 for the tracking issue of these features.
 
 This source is currently experimental, so in order to use it, you need to first 
 add `"document_symbols"` to `config.sources` and open it with the command

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1319,7 +1319,8 @@ Fired before opening a new Neo-tree window. Called with the following arg:
                                                      *neo-tree-window-event-args*
 The event argument for all window events is a table with the following keys:
     `winid`    = the |winid| of the window being opened or closed.
-    `tabnr`    = the tab number that the window is in.
+    `tabid`    = id of the tab that the window is in.
+    `tabnr`    = (deprecated) number of the tab that the window is in.
     `source`   = the name of the source that is in the window, such as "filesystem".
     `position` = the position of the window, i.e. "left", "bottom", "right".
 
@@ -1620,7 +1621,8 @@ code or integrations if you need it. The |filetype| of the main window is
 `neo-tree`. The buffer will also have these local variables set:
 
 `winid` The window handle of the window that it was created in.
-`tabnr` The tab number that it was created in.
+`tabid` The id of the tab that it was created in.
+`tabnr` (deprecated) The number of the tab that it was created in.
 `source` The name of the source that created it, i.e. filesystem, buffers, etc.
 
 Please note that if the buffer is displayed in another window or tab, it's

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -60,9 +60,9 @@ control over the details of what and where it will show. Arguments can be
 specified as either a key=value pair or just as the value. The key=value form
 is more verbose but may help with clarity. For example, the "buffers" command
 above can also be specified as:
-
+>vim
     :Neotree action=show source=buffers position=right toggle=true
-
+<
 These arguments can be specified in any order. Here is the full list of 
 arguments you can use:
 
@@ -144,7 +144,7 @@ should change their mapping to the new |:Neotree| command specified above.
 
 Once you have migrated your mappings, it is recommended that you remove the old
 commands by adding this option before the Neotree config is run:
->
+>vim
   let g:neo_tree_remove_legacy_commands = 1
 <
 
@@ -300,7 +300,7 @@ FILTER                                                        *neo-tree-filter*
 
 NOTE: All of the below commands are affected by the `find_by_full_path_words`
 option:
->
+>lua
     require("neo-tree").setup({
       filesystem = {
         find_by_full_path_words = false,  
@@ -352,7 +352,7 @@ switching focus from the Neo-tree window. By default, files will be previewed
 in a new floating window. This can also be configured to automatically choose 
 an existing split by configuring the command like this:
 
->
+>lua
     require("neo-tree").setup({
       window = {
         mappings = {
@@ -382,7 +382,7 @@ source level, such as `filesystem.window.mappings` will override and extend
 those global mappings for that particular source. 
 
 For example:
->
+>lua
    require("neo-tree").setup({
      window = {
        mappings = {
@@ -409,7 +409,7 @@ the sequence to `none` or `noop`. For example, if you don’t wish to use
 fuzzy finder (default mapping `/`), but instead rely on Neovim’s built-in
 search functionality, you can do that like so this:
 
->
+>lua
    require("neo-tree").setup({
      filesystem = {
        window = {
@@ -435,7 +435,7 @@ If you want to define your own command, you have two options:
   2. You can map directly to a function and skip defining a command.
 
 You probably want #2:
->
+>lua
    require("neo-tree").setup({
      filesystem = {
        window = {
@@ -450,7 +450,7 @@ You probably want #2:
    })
 <
 ..or
->
+>lua
    local print_me = function(state)
      local node = state.tree:get_node()
      print(node.name)
@@ -468,7 +468,7 @@ You probably want #2:
 <
 ...but if you want #1, here is how that works:
 
->
+>lua
    require("neo-tree").setup({
      filesystem = {
        commands = {
@@ -528,13 +528,13 @@ which is a list of the nodes that were selected when the command was called.
 
 For example, this is how the built-in `delete` command is defined:
 
->
+>lua
     M.delete = function(state, callback)
       local tree = state.tree
       local node = tree:get_node()
       fs_actions.delete_node(node.path, callback)
     end
-    
+
     M.delete_visual = function(state, selected_nodes, callback)
       local paths_to_delete = {}
       for _, node_to_delete in pairs(selected_nodes) do
@@ -555,7 +555,7 @@ overrides the global `mapping_options`
 The command can be either the string name of a built-in command, or a
 function, and is specified either as the first element in the table or by
 assigning it to the `command` key:
->
+>lua
    require("neo-tree").setup({
      filesystem = {
        window = {
@@ -599,7 +599,7 @@ CUSTOM MAPPINGS WITH CONFIG
 Some mappings may accept an optional `config` table to control it's behavior.
 When that is the case, the command is specified using the table syntax, and
 the config options are in a table bound to the `config` key:
->
+>lua
    require("neo-tree").setup({
      filesystem = {
        window = {
@@ -618,7 +618,7 @@ the config options are in a table bound to the `config` key:
 <
 When the `config` key is used, it is added to the `state` argument that is
 passed to the command function:
->
+>lua
     M.add = function(state, callback)
       local show_path = state.config.show_path
       ...
@@ -665,7 +665,7 @@ SETUP                                                           *neo-tree-setup*
 To override the defaults or add new functionality, call the setup() function
 with your overrides. For example, to add your own mappings in 'lua':
 
->
+>lua
     require("neo-tree").setup({
       filesystem = {
         window = {
@@ -696,12 +696,12 @@ You can enable a clickable source selector in either the winbar
 (requires neovim 0.8+) or the statusline. To do so, set one of these options
 to `true`:
 
->
+>lua
     requires("neo-tree").setup({
-        source_selector = {
-            winbar = false,
-            statusline = false
-        }
+      source_selector = {
+        winbar = false,
+        statusline = false
+      }
     })
 <
 
@@ -709,41 +709,41 @@ The configuration options for source selector are all placed inside
 `source_selector` table. Below are the options with their default values and
 type notations.
 
->
+>lua
     requires("neo-tree").setup({
-        source_selector = {
-            winbar = false, -- toggle to show selector on winbar
-            statusline = false, -- toggle to show selector on statusline
-            show_scrolled_off_parent_node = false,                    -- boolean
-            sources = {                                               -- table
-                {
-                    source = "filesystem",                            -- string
-                    display_name = "  Files "                        -- string | nil
-                },
-                {
-                    source = "buffers",                               -- string
-                    display_name = "  Buffers                        -- string | nil
-                },
-                {
-                    source = "git_status",                            -- string
-                    display_name = "  Git "                          -- string | nil
-                },
-            },
-            content_layout = "start",                                 -- string
-            tabs_layout = "equal",                                    -- string
-            truncation_character = "…",                               -- string
-            tabs_min_width = nil,                                     -- int | nil
-            tabs_max_width = nil,                                     -- int | nil
-            padding = 0,                                              -- int | { left: int, right: int }
-            separator = { left = "▏", right= "▕" },                   -- string | { left: string, right: string, override: string | nil }
-            separator_active = nil,                                   -- string | { left: string, right: string, override: string | nil } | nil
-            show_separator_on_edge = false,                           -- boolean
-            highlight_tab = "NeoTreeTabInactive",                     -- string
-            highlight_tab_active = "NeoTreeTabActive",                -- string
-            highlight_background = "NeoTreeTabInactive",              -- string
-            highlight_separator = "NeoTreeTabSeparatorInactive",      -- string
-            highlight_separator_active = "NeoTreeTabSeparatorActive", -- string
+      source_selector = {
+        winbar = false, -- toggle to show selector on winbar
+        statusline = false, -- toggle to show selector on statusline
+        show_scrolled_off_parent_node = false,                    -- boolean
+        sources = {                                               -- table
+          {
+            source = "filesystem",                                -- string
+            display_name = "  Files "                            -- string | nil
+          },
+          {
+            source = "buffers",                                   -- string
+            display_name = "  Buffers "                          -- string | nil
+          },
+          {
+            source = "git_status",                                -- string
+            display_name = "  Git "                              -- string | nil
+          },
         },
+        content_layout = "start",                                 -- string
+        tabs_layout = "equal",                                    -- string
+        truncation_character = "…",                               -- string
+        tabs_min_width = nil,                                     -- int | nil
+        tabs_max_width = nil,                                     -- int | nil
+        padding = 0,                                              -- int | { left: int, right: int }
+        separator = { left = "▏", right= "▕" },                   -- string | { left: string, right: string, override: string | nil }
+        separator_active = nil,                                   -- string | { left: string, right: string, override: string | nil } | nil
+        show_separator_on_edge = false,                           -- boolean
+        highlight_tab = "NeoTreeTabInactive",                     -- string
+        highlight_tab_active = "NeoTreeTabActive",                -- string
+        highlight_background = "NeoTreeTabInactive",              -- string
+        highlight_separator = "NeoTreeTabSeparatorInactive",      -- string
+        highlight_separator_active = "NeoTreeTabSeparatorActive", -- string
+      },
     })
 <
 
@@ -822,7 +822,7 @@ with the window local working directory (|lcd|).
 
 These defaults can be changed by setting the following options:
 
->
+>lua
     require("neo-tree").setup({
       filesystem = {
         bind_to_cwd = true, -- true creates a 2-way binding between vim's cwd and neo-tree's root
@@ -837,7 +837,7 @@ These defaults can be changed by setting the following options:
 In addition to `"tab"` and `"window"`, you can also set the target to `"global"`
 for either option, which is the same as using the |cd| command. Setting the target
 to `"none"` will prevent neo-tree from setting vim's cwd for that position.
-        
+
 
 FILTERED ITEMS                                         *neo-tree-filtered-items*
 
@@ -848,7 +848,7 @@ be toggled on and off with a command. Each type of filter has a corresponding
 highlight group which will be applied when they are visible, see 
 |neo-tree-highlights| for details. The following options are available:
 
->
+>lua
     require("neo-tree").setup({
       filesystem = {
         filtered_items = {
@@ -873,7 +873,7 @@ highlight group which will be applied when they are visible, see
             --"thumbs.db",
           },
           never_show_by_pattern = { -- uses glob style patterns
-              --".null-ls_*",
+            --".null-ls_*",
           },
         },
       }
@@ -925,11 +925,11 @@ open_default (default) Netrw disabled, opening a directory opens neo-tree
 open_current           Netrw disabled, opening a directory opens within the
                        window like netrw would, regardless of `window.position`.
 
->
+>lua
     require("neo-tree").setup({
       filesystem = {
         hijack_netrw_behavior = "open_default",
-                             -- "open_current",  
+                             -- "open_current",
                              -- "disabled", 
     })
 <
@@ -948,7 +948,7 @@ components in a universal way, the best place to do that is in the
 For example, to add indent markers, you can apply your settings in each renderer
 for each source, or just do it once in the default_component_configs section:
 
->
+>lua
     require("neo-tree").setup({
       default_component_configs = {
         indent = {
@@ -980,7 +980,7 @@ component of your renderer(s).
 Starting with 2.0, this will display symbols by default. The default symbols
 will require a nerd font to be installed. To change these symbols, you can set
 the following properties:
->
+>lua
     require("neo-tree").setup({
       default_component_configs = {
         symbols = {
@@ -1013,7 +1013,7 @@ If you'd like to disable certain symbols, you can set them to an empty string.
 For example, it is actually redundant to show the change type if you use the
 default behavior of highlighting the file name according to the change type.
 The following config will remove those change type symbols:
->
+>lua
     require("neo-tree").setup({
       default_component_configs = {
         symbols = {
@@ -1036,7 +1036,7 @@ The following config will remove those change type symbols:
 To revert to the previous behavior of passing the git status through as-is
 with codes like `[M ]` for changed/unstaged, and `[ M]` for changed/staged,
 you can set the `symbols` property to nil or false:
->
+>lua
     require("neo-tree").setup({
       default_component_configs = {
         git_status = {
@@ -1055,7 +1055,7 @@ display the highest severity level for files, and errors only for directories.
 If you want to use symbols instead of "E", "W", "I", and H", you'll need to
 define those somewhere in your nvim configuration. Here is an example:
 
->
+>lua
     vim.fn.sign_define("LspDiagnosticsSignError",
         {text = " ", texthl = "LspDiagnosticsSignError"})
     vim.fn.sign_define("LspDiagnosticsSignWarning",
@@ -1069,7 +1069,7 @@ define those somewhere in your nvim configuration. Here is an example:
 Alternatively, you can also specify the signs and/or highlights in the
 neo-tree setup call like this:
 
->
+>lua
     require("neo-tree").setup({
       default_component_configs = {
         diagnostics = {
@@ -1103,7 +1103,7 @@ indent is a component, so to enable indent markers, you need configure the
 `indent` component:
 
 ...at the global level:
->
+>lua
     require("neo-tree").setup({
       default_component_configs = {
         indent = {
@@ -1117,31 +1117,32 @@ indent is a component, so to enable indent markers, you need configure the
 <
 
 ...or in each renderer:
->
+>lua
     require("neo-tree").setup({
-        filesystem = {
-            renderers = {
-              directory = {
-                {
-                  "indent",
-                  with_markers = true,
-                  indent_marker = "│",
-                  last_indent_marker = "└",
-                  indent_size = 2,
-                },
-                -- other components
-              },
-              file = {
-                {
-                  "indent",
-                  with_markers = true,
-                  indent_marker = "│",
-                  last_indent_marker = "└",
-                  indent_size = 2,
-                -- other components
-              },
-            }
+      filesystem = {
+        renderers = {
+          directory = {
+            {
+              "indent",
+              with_markers = true,
+              indent_marker = "│",
+              last_indent_marker = "└",
+              indent_size = 2,
+            },
+            -- other components
+          },
+          file = {
+            {
+              "indent",
+              with_markers = true,
+              indent_marker = "│",
+              last_indent_marker = "└",
+              indent_size = 2,
+            },
+            -- other components
+          },
         }
+      }
     })
 <
 
@@ -1156,16 +1157,16 @@ EXPANDERS                                                   *neo-tree-expanders*
 Is hightly recommended enable if file nesting is enabled (this is the default
 behavior if `with_expanders` is nil). The config can be done inside the `indent`
 component:
->
+>lua
     require("neo-tree").setup({
-        default_component_configs = {
-            indent = {
-                with_expanders = true,
-                expander_collapsed = "",
-                expander_expanded = "",
-                expander_highlight = "NeoTreeExpander",
-            },
+      default_component_configs = {
+        indent = {
+          with_expanders = true,
+          expander_collapsed = "",
+          expander_expanded = "",
+          expander_highlight = "NeoTreeExpander",
         },
+      },
     })
 <
 
@@ -1174,11 +1175,11 @@ FILE NESTING                                             *neo-tree-file-nesting*
 By default, file nesting is disabled since the `nesting_rules` table is empty.
 To enable this feature, fill in the `nesting_rules` table with the following
 structure:
->
+>lua
     require("neo-tree").setup({
-        nesting_rules = {
-            ["js"] = { "js.map" },
-        }
+      nesting_rules = {
+        ["js"] = { "js.map" },
+      }
     })
 <
 This will render:
@@ -1245,7 +1246,7 @@ Events are one way to customize the behavior of Neo-tree. You can add event
 handlers to your config in the `event_handlers` section, which should be a list
 of objects in the form:
 
->
+>lua
     {
       event = "event_name",
       handler = function(arg)
@@ -1365,7 +1366,7 @@ Fired on the |ColorScheme| autocmd event
 
 You can also define your own with:
 >
->
+>lua
     require("neo-tree.events.queue").define_event(event_name, {
       setup = <function>,
       seed = <function>,
@@ -1402,7 +1403,7 @@ A renderer is just a list of component configs, to be rendered in order to
 create a line in the tree. Each renderer is for a specific node type, such as
 `directory` or `file`.  To view the available built-in components and their
 configs for each source, look at the default config by pasting it with
->
+>vim
     :lua require("neo-tree").paste_default_config()
 <
 or view it online at:
@@ -1415,7 +1416,7 @@ configs.
 
                                                            *neo-tree-components*
 A component is a function that returns a single text object:
->
+>lua
     {
       text = "Node A",
       highlight = "Normal"
@@ -1423,7 +1424,7 @@ A component is a function that returns a single text object:
 <
 
 ... or a list of text objects:
->
+>lua
     {
       {
         text = "Node Name",
@@ -1523,8 +1524,7 @@ This example container has the name on the left hand side, and the
 diagnostics and git status aligned to the right hand side of the window. The
 diagnostics and git_status will always be shown, and the name will be clipped if
 there is not enough space:
->
-
+>lua
       {
         "container",
         width = "100%",
@@ -1538,6 +1538,7 @@ there is not enough space:
           { "diagnostics",  zindex = 20, align = "right" },
           { "git_status", zindex = 20, align = "right" },
         },
+      }
 <
 
 
@@ -1562,7 +1563,7 @@ Each component function is called with the following args:
 
 For example, here is the simplest possible component:
 
->
+>lua
     require("neo-tree").setup({
       filesystem = {
         components = {
@@ -1582,7 +1583,7 @@ For example, here is the simplest possible component:
 For a more complete example, here is the actual built-in `name` component, which
 is much more dynamic and configurable:
 
->
+>lua
     require("neo-tree").setup({
       filesystem = {
         components = {
@@ -1683,7 +1684,7 @@ empty.
 
 This view has most file commands except for "add", plus the following git
 specific commands:
-
+>lua
       ["A"]  = "git_add_all",
       ["ga"] = "git_add_file",
       ["gu"] = "git_unstage_file",
@@ -1691,7 +1692,7 @@ specific commands:
       ["gc"] = "git_commit"
       ["gp"] = "git_push",
       ["gg"] = "git_commit_and_push",
-
+<
 
 DOCUMENT SYMBOLS                                     *neo-tree-document-symbols*
 
@@ -1719,7 +1720,7 @@ https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/spe
 server_filter~
 This option could be used to set which LSP server is used to obtain the document
 symbols. This accepts one of the following values
-  
+
   `"first"`: use the first LSP server that provides the feature
   `"all"`: use all LSP server that provides the feature
   `{ fn = function(name), white_list = table, black_list = table }` where
@@ -1729,7 +1730,7 @@ symbols. This accepts one of the following values
       NOTE: `fn` preceeds `white_list` preceeds `black_list`
 
 For example: (NOTE: here only `fn` will be taken into account)
->
+>lua
   { 
     fn = function(name) return name ~= "null-ls" end,
     white_list = { "clangd", "lua_ls" },
@@ -1737,10 +1738,10 @@ For example: (NOTE: here only `fn` will be taken into account)
   }
 <
 Currently, this source supports the following commands:
-    
+>lua
     ["o"] = "jump_to_symbol",
     ["r"] = "rename",
     ["P"] = "preview", (and related commands)
     ["s"] = "split", (and related commands)
-
+<
 vim:tw=80:ts=2:et:ft=help:

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1698,6 +1698,9 @@ by the LSP request "textDocument/documentSymbols".
 
 Its configuration includes the following options:
 
+follow_cursor~
+If set to `true`, will automatically focus on the symbol under the cursor.
+
 kinds~
 A table specifying how LSP kinds should be rendered. Each entry should map the
 LSP kind name to an icon and a highlight group, for example 

--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -165,8 +165,8 @@ M.get_prior_window = function(ignore_filetypes)
   local ignore = utils.list_to_dict(ignore_filetypes)
   ignore["neo-tree"] = true
 
-  local tabnr = vim.api.nvim_get_current_tabpage()
-  local wins = utils.get_value(M, "config.prior_windows", {}, true)[tabnr]
+  local tabid = vim.api.nvim_get_current_tabpage()
+  local wins = utils.get_value(M, "config.prior_windows", {}, true)[tabid]
   if wins == nil then
     return -1
   end

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -72,7 +72,8 @@ M.execute = function(args)
 
   -- Now get the correct state
   local state
-  if args.position == "current" then
+  local requested_position = args.position or nt.config[args.source].window.position
+  if requested_position == "current" then
     local winid = vim.api.nvim_get_current_win()
     state = manager.get_state(args.source, nil, winid)
   else

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -514,6 +514,7 @@ local config = {
     },
   },
   document_symbols = {
+    follow_cursor = false,
     client_filters = "first",
     renderers = {
       root = {

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -293,7 +293,7 @@ M.win_enter_event = function()
         for filename, buf_info in pairs(mod) do
           if buf_info.modified then
             if vim.startswith(filename, "[No Name]#") then
-              bufnr = string.sub(filename, 11)
+              local bufnr = string.sub(filename, 11)
               log.trace("close_if_last_window, showing unnamed modified buffer: ", filename)
               vim.schedule(function()
                 log.warn(

--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -5,14 +5,15 @@ local command = require("neo-tree.command")
 local M = {}
 
 local get_position = function(source_name)
-  local pos = utils.get_value(M, "config." .. source_name .. ".window.position", "left")
+  local nt = require("neo-tree")
+  local pos = utils.get_value(nt.config, source_name .. ".window.position", "left", true)
   return pos
 end
 
 M.get_hijack_netrw_behavior = function()
   local nt = require("neo-tree")
   local option = "filesystem.hijack_netrw_behavior"
-  local hijack_behavior = utils.get_value(nt.config, option, "open_default")
+  local hijack_behavior = utils.get_value(nt.config, option, "open_default", true)
   if hijack_behavior == "disabled" then
     return hijack_behavior
   elseif hijack_behavior == "open_default" then

--- a/lua/neo-tree/sources/buffers/init.lua
+++ b/lua/neo-tree/sources/buffers/init.lua
@@ -59,8 +59,8 @@ M.follow = function()
 end
 
 local buffers_changed_internal = function()
-  for _, tabnr in ipairs(vim.api.nvim_list_tabpages()) do
-    local state = manager.get_state(M.name, tabnr)
+  for _, tabid in ipairs(vim.api.nvim_list_tabpages()) do
+    local state = manager.get_state(M.name, tabid)
     if state.path and renderer.window_exists(state) then
       items.get_opened_buffers(state)
       if state.follow_current_file then

--- a/lua/neo-tree/sources/document_symbols/commands.lua
+++ b/lua/neo-tree/sources/document_symbols/commands.lua
@@ -22,7 +22,7 @@ M.jump_to_symbol = function(state, node)
   end
   vim.api.nvim_set_current_win(state.lsp_winid)
   local symbol_loc = node.extra.selection_range.start
-  vim.api.nvim_win_set_cursor(state.lsp_winid, { symbol_loc[1], symbol_loc[2] })
+  vim.api.nvim_win_set_cursor(state.lsp_winid, { symbol_loc[1] + 1, symbol_loc[2] })
 end
 
 M.rename = function(state)

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -20,8 +20,8 @@ local wrap = function(func)
   return utils.wrap(func, M.name)
 end
 
-local get_state = function(tabnr)
-  return manager.get_state(M.name, tabnr)
+local get_state = function(tabid)
+  return manager.get_state(M.name, tabid)
 end
 
 -- TODO: DEPRECATED in 1.19, remove in 2.0

--- a/tests/neo-tree/sources/manager_spec.lua
+++ b/tests/neo-tree/sources/manager_spec.lua
@@ -1,0 +1,125 @@
+pcall(require, "luacov")
+
+local u = require("tests.utils")
+local verify = require("tests.utils.verify")
+
+local manager = require('neo-tree.sources.manager')
+
+local get_dirs = function(winid)
+  winid = winid or vim.api.nvim_get_current_win()
+  local tabnr = vim.api.nvim_tabpage_get_number(vim.api.nvim_win_get_tabpage(winid))
+  local winnr = vim.api.nvim_win_get_number(winid)
+  return {
+    win = vim.fn.getcwd(winnr),
+    tab = vim.fn.getcwd(-1, tabnr),
+    global = vim.fn.getcwd(-1, -1),
+  }
+end
+
+local get_state_for_tab = function(tabid)
+  for _, state in ipairs(manager._get_all_states()) do
+    if state.tabid == tabid then
+      return state
+    end
+  end
+end
+
+local get_tabnr = function(tabid)
+    return vim.api.nvim_tabpage_get_number(tabid or vim.api.nvim_get_current_tabpage())
+end
+
+describe("Manager", function()
+  local test = u.fs.init_test({
+    items = {
+      {
+        name = "foo",
+        type = "dir",
+        items = {
+          { name = "foofile1.txt", type = "file" },
+        },
+      },
+      { name = "topfile1.txt", type = "file", id = "topfile1" },
+    },
+  })
+
+  test.setup()
+
+  local fs_tree = test.fs_tree
+
+  -- Just make sure we start all tests in the expected state
+  before_each(function()
+    u.eq(1, #vim.api.nvim_list_wins())
+    u.eq(1, #vim.api.nvim_list_tabpages())
+    vim.cmd.lcd(fs_tree.abspath)
+    vim.cmd.tcd(fs_tree.abspath)
+    vim.cmd.cd(fs_tree.abspath)
+  end)
+
+  after_each(function()
+    u.clear_environment()
+  end)
+
+  local setup_2_tabs = function()
+    -- create 2 tabs
+    local tab1 = vim.api.nvim_get_current_tabpage()
+    local win1 = vim.api.nvim_get_current_win()
+    vim.cmd.tabnew()
+    local tab2 = vim.api.nvim_get_current_tabpage()
+    local win2 = vim.api.nvim_get_current_win()
+    u.neq(tab2, tab1)
+    u.neq(win2, win1)
+
+    -- set different directories
+    vim.api.nvim_set_current_tabpage(tab2)
+    local base_dir = vim.fn.getcwd()
+    vim.cmd.tcd('foo')
+    local new_dir = vim.fn.getcwd()
+
+    -- open neo-tree
+    vim.api.nvim_set_current_tabpage(tab1)
+    vim.cmd.Neotree('show')
+    vim.api.nvim_set_current_tabpage(tab2)
+    vim.cmd.Neotree('show')
+
+    return {
+      tab1 = tab1,
+      tab2 = tab2,
+      win1 = win1,
+      win2 = win2,
+      tab1_dir = base_dir,
+      tab2_dir = new_dir,
+    }
+  end
+
+  it("should respect changed tab cwd", function()
+    local ctx = setup_2_tabs()
+
+    local state1 = get_state_for_tab(ctx.tab1)
+    local state2 = get_state_for_tab(ctx.tab2)
+    u.eq(ctx.tab1_dir, manager.get_cwd(state1))
+    u.eq(ctx.tab2_dir, manager.get_cwd(state2))
+  end)
+
+  it("should have correct tab cwd after  tabs order is changed", function()
+    local ctx = setup_2_tabs()
+
+    -- tab numbers should be the same as ids
+    u.eq(1, get_tabnr(ctx.tab1))
+    u.eq(2, get_tabnr(ctx.tab2))
+
+    -- swap tabs
+    vim.cmd.tabfirst()
+    vim.cmd.tabmove('+1')
+
+    -- make sure tabs have been swapped
+    u.eq(2, get_tabnr(ctx.tab1))
+    u.eq(1, get_tabnr(ctx.tab2))
+
+    -- verify that tab dirs are the same as nvim tab cwd
+    local state1 = get_state_for_tab(ctx.tab1)
+    local state2 = get_state_for_tab(ctx.tab2)
+    u.eq(get_dirs(ctx.win1).tab, manager.get_cwd(state1))
+    u.eq(get_dirs(ctx.win2).tab, manager.get_cwd(state2))
+  end)
+end)
+


### PR DESCRIPTION
- feat(document_symbols): added follow_cursor(#880)
- fix: set correct winid when window.position = current (#874)
- fix: declare `bufnr` as local to avoid polluting global namespace (#883)
- fix!: use correct conversion between tabid and tabnr when tracking cwd (#842)
- Update doc
